### PR TITLE
Make Tab indent the whole line when cursor is at the beginning of a list item

### DIFF
--- a/src/translations/nanonote_es.ts
+++ b/src/translations/nanonote_es.ts
@@ -4,12 +4,12 @@
 <context>
     <name>IndentExtension</name>
     <message>
-        <location filename="../IndentExtension.cpp" line="51"/>
+        <location filename="../IndentExtension.cpp" line="67"/>
         <source>Indent</source>
         <translation>Sangrar el texto</translation>
     </message>
     <message>
-        <location filename="../IndentExtension.cpp" line="58"/>
+        <location filename="../IndentExtension.cpp" line="74"/>
         <source>Unindent</source>
         <translation>Quitar sangrado de texto</translation>
     </message>

--- a/src/translations/nanonote_fr.ts
+++ b/src/translations/nanonote_fr.ts
@@ -4,12 +4,12 @@
 <context>
     <name>IndentExtension</name>
     <message>
-        <location filename="../IndentExtension.cpp" line="51"/>
+        <location filename="../IndentExtension.cpp" line="67"/>
         <source>Indent</source>
         <translation>Indenter</translation>
     </message>
     <message>
-        <location filename="../IndentExtension.cpp" line="58"/>
+        <location filename="../IndentExtension.cpp" line="74"/>
         <source>Unindent</source>
         <translation>Désindenter</translation>
     </message>

--- a/tests/IndentExtensionTest.cpp
+++ b/tests/IndentExtensionTest.cpp
@@ -77,4 +77,32 @@ TEST_CASE("textedit") {
         QTest::keyClick(edit, Qt::Key_Tab);
         REQUIRE(edit->toPlainText() == QString("    aa\n    bb\n"));
     }
+
+    SECTION("indent at start of unindented list") {
+        edit->setPlainText("- item\n- \n");
+        edit->moveCursor(QTextCursor::Down);
+        edit->moveCursor(QTextCursor::Right);
+        edit->moveCursor(QTextCursor::Right);
+        QTest::keyClick(edit, Qt::Key_Tab);
+        REQUIRE(edit->toPlainText() == QString("- item\n    - \n"));
+    }
+
+    SECTION("indent at start of unindented list, no trailing newline") {
+        edit->setPlainText("- item\n- ");
+        edit->moveCursor(QTextCursor::Down);
+        edit->moveCursor(QTextCursor::Right);
+        edit->moveCursor(QTextCursor::Right);
+        QTest::keyClick(edit, Qt::Key_Tab);
+        REQUIRE(edit->toPlainText() == QString("- item\n    - "));
+    }
+
+    SECTION("indent at start of indented list") {
+        edit->setPlainText("    - item\n    - ");
+        edit->moveCursor(QTextCursor::Down);
+        for (int i = 0; i < 6; ++i) {
+            edit->moveCursor(QTextCursor::Right);
+        }
+        QTest::keyClick(edit, Qt::Key_Tab);
+        REQUIRE(edit->toPlainText() == QString("    - item\n        - "));
+    }
 }


### PR DESCRIPTION
This is especially useful when new bullets are automatically inserted
when pressing Enter. In this case, pressing Tab will now increase the
indentation level of the list instead of adding spaces after the list
bullet character.

Fixes #4

I am a little bit unsure if this was the best way to implement the feature and not too happy with having to create `findListPrefix()`. My first approach was to use findCommonPrefix() and running findBulletSize on the last two characters, which would add the assumption that bullets are always two characters long. If you think there is a more elegant way to implement this, I'm happy to learn from it.