### PR TITLE
add action to reset the font size to the default value

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -33,6 +33,7 @@ void MainWindowExtension::aboutToShowContextMenu(QMenu *menu, const QPoint &)
 {
     menu->addAction(mWindow->mIncreaseFontAction);
     menu->addAction(mWindow->mDecreaseFontAction);
+    menu->addAction(mWindow->mResetFontAction);
     menu->addAction(mWindow->mAlwaysOnTopAction);
     menu->addSeparator();
     menu->addAction(mWindow->mSettingsAction);
@@ -46,6 +47,7 @@ MainWindow::MainWindow(QWidget *parent)
     , mAutoSaveTimer(new QTimer(this))
     , mIncreaseFontAction(new QAction(this))
     , mDecreaseFontAction(new QAction(this))
+    , mResetFontAction(new QAction(this))
     , mAlwaysOnTopAction(new QAction(this))
     , mSettingsAction(new QAction(this))
 {
@@ -94,11 +96,16 @@ void MainWindow::setupActions()
     mDecreaseFontAction->setText(tr("Decrease Font Size"));
     mDecreaseFontAction->setShortcut(QKeySequence::ZoomOut);
 
+    mResetFontAction->setText(tr("Reset Font Size"));
+    mResetFontAction->setShortcut(Qt::CTRL + Qt::Key_0);
+
     connect(mIncreaseFontAction, &QAction::triggered, this, [this] { adjustFontSize(1); });
     connect(mDecreaseFontAction, &QAction::triggered, this, [this] { adjustFontSize(-1); });
+    connect(mResetFontAction, &QAction::triggered, this, [this] { resetFontSize(); });
 
     addAction(mIncreaseFontAction);
     addAction(mDecreaseFontAction);
+    addAction(mResetFontAction);
 
     mAlwaysOnTopAction->setText(tr("Always on Top"));
     mAlwaysOnTopAction->setShortcut(Qt::CTRL + Qt::Key_T);
@@ -218,6 +225,15 @@ void MainWindow::adjustFontSize(int delta)
 {
     QFont font = mSettings->font();
     font.setPointSize(font.pointSize() + delta);
+    mSettings->setFont(font);
+    saveSettings();
+}
+
+void MainWindow::resetFontSize()
+{
+    QFont font = mSettings->font();
+    QFont defaultFont = mSettings->defaultFont();
+    font.setPointSize(defaultFont.pointSize());
     mSettings->setFont(font);
     saveSettings();
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -101,7 +101,7 @@ void MainWindow::setupActions()
 
     connect(mIncreaseFontAction, &QAction::triggered, this, [this] { adjustFontSize(1); });
     connect(mDecreaseFontAction, &QAction::triggered, this, [this] { adjustFontSize(-1); });
-    connect(mResetFontAction, &QAction::triggered, this, [this] { resetFontSize(); });
+    connect(mResetFontAction, &QAction::triggered, this, &MainWindow::resetFontSize);
 
     addAction(mIncreaseFontAction);
     addAction(mDecreaseFontAction);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -45,6 +45,7 @@ private:
     void loadSettings();
     void saveSettings();
     void adjustFontSize(int delta);
+    void resetFontSize();
     void setAlwaysOnTop(bool onTop);
     void showSettingsDialog();
 
@@ -54,6 +55,7 @@ private:
 
     QAction* mIncreaseFontAction;
     QAction* mDecreaseFontAction;
+    QAction* mResetFontAction;
     QAction* mAlwaysOnTopAction;
     QAction* mSettingsAction;
     QPointer<SettingsDialog> mSettingsDialog;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -26,7 +26,7 @@ void Settings::load()
     if (fontVariant.canConvert<QFont>()) {
         setFont(fontVariant.value<QFont>());
     } else {
-        setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+        setFont(defaultFont());
     }
 
     setAlwaysOnTop(settings.value("alwaysOnTop").toBool());
@@ -38,4 +38,9 @@ void Settings::save()
     settings.setValue("geometry", geometry());
     settings.setValue("font", font());
     settings.setValue("alwaysOnTop", alwaysOnTop());
+}
+
+QFont Settings::defaultFont() const
+{
+    return QFontDatabase::systemFont(QFontDatabase::FixedFont);
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -11,6 +11,7 @@ public:
     static QString notePath();
     void load();
     void save();
+    QFont defaultFont() const;
 };
 
 #endif // SETTINGS_H

--- a/src/translations/nanonote_es.ts
+++ b/src/translations/nanonote_es.ts
@@ -89,6 +89,10 @@ Finalmente, se puede sangrar las líneas seleccionadas pulsando el tabulador o m
 Y esto es todo lo que hay que decir, ahora puedes eliminar este texto ¡y empezar a tomar notas!
 </translation>
     </message>
+    <message>
+        <source>Reset Font Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsDialog</name>

--- a/src/translations/nanonote_fr.ts
+++ b/src/translations/nanonote_fr.ts
@@ -89,6 +89,10 @@ Enfin, vous pouvez indenter les lignes sélectionnées avec Tab ou Ctrl+I et les
 C&apos;est tout ce qu&apos;il y a dire, maintenant vous pouvez effacer ce texte et commencer à prendre des notes !
 </translation>
     </message>
+    <message>
+        <source>Reset Font Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsDialog</name>


### PR DESCRIPTION
I added an action that allows for the font size to be reset to the default value. Similarly to what most browsers use, the shortcut is Ctrl+0.

My use case is the following: I sometimes enlarge the font size to absurd values when multiple people are looking at my screen from a distance. It will be convenient to get back to a reasonable font size in a single step.