### PR TITLE
use the link color of the color theme instead of hardcoding Qt::blue

### DIFF
--- a/src/LinkSyntaxHighlighter.cpp
+++ b/src/LinkSyntaxHighlighter.cpp
@@ -1,6 +1,8 @@
 #include "LinkSyntaxHighlighter.h"
 
 #include <QRegularExpression>
+#include <QGuiApplication>
+#include <QPalette>
 
 // These chars are allowed anywhere in the url
 #define COMMON_CHARS "-_a-zA-Z0-9/?=&#"
@@ -19,8 +21,9 @@ LinkSyntaxHighlighter::LinkSyntaxHighlighter(QTextDocument *document)
 void LinkSyntaxHighlighter::highlightBlock(const QString &text)
 {
     QTextCharFormat linkFormat;
-    linkFormat.setForeground(Qt::blue);
-    linkFormat.setUnderlineColor(Qt::blue);
+    QColor linkColor = QGuiApplication::palette().color(QPalette::Link);
+    linkFormat.setForeground(linkColor);
+    linkFormat.setUnderlineColor(linkColor);
     linkFormat.setUnderlineStyle(QTextCharFormat::SingleUnderline);
 
     QRegularExpression expression(LINK_REGEX);


### PR DESCRIPTION
screenshots when using Breeze Dark as the color theme

before:
![before](https://user-images.githubusercontent.com/3208721/55145929-f36a4f00-5143-11e9-86d9-911820efddee.png)

after:
![after](https://user-images.githubusercontent.com/3208721/55145939-f9603000-5143-11e9-8953-72220da2d426.png)
