### PR TITLE
increase/decrease the font size by scrolling while pressing Ctrl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(nanonote_SRCS
     SettingsDialog.cpp
     SettingsDialog.ui
     TextEdit.cpp
+    WheelZoomExtension.cpp
 )
 
 qt5_add_resources(nanonote_RESOURCES nanonote.qrc)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -74,7 +74,7 @@ void MainWindow::setupTextEdit()
 
     WheelZoomExtension *wheelZoomExtension = new WheelZoomExtension(mTextEdit);
     mTextEdit->addExtension(wheelZoomExtension);
-    QObject::connect(wheelZoomExtension, &WheelZoomExtension::adjustFontSize, this, &MainWindow::adjustFontSize);
+    connect(wheelZoomExtension, &WheelZoomExtension::adjustFontSize, this, &MainWindow::adjustFontSize);
 
     mTextEdit->addExtension(new MainWindowExtension(this));
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -15,6 +15,7 @@
 
 #include "IndentExtension.h"
 #include "LinkExtension.h"
+#include "WheelZoomExtension.h"
 #include "Settings.h"
 #include "SettingsDialog.h"
 #include "TextEdit.h"
@@ -70,6 +71,11 @@ void MainWindow::setupTextEdit()
     mTextEdit->setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
     mTextEdit->addExtension(new LinkExtension(mTextEdit));
     mTextEdit->addExtension(new IndentExtension(mTextEdit));
+
+    WheelZoomExtension *wheelZoomExtension = new WheelZoomExtension(mTextEdit);
+    mTextEdit->addExtension(wheelZoomExtension);
+    QObject::connect(wheelZoomExtension, &WheelZoomExtension::adjustFontSize, this, &MainWindow::adjustFontSize);
+
     mTextEdit->addExtension(new MainWindowExtension(this));
 }
 

--- a/src/TextEdit.cpp
+++ b/src/TextEdit.cpp
@@ -29,6 +29,10 @@ bool TextEditExtension::mouseRelease(QMouseEvent */*event*/) {
     return false;
 }
 
+bool TextEditExtension::wheel(QWheelEvent */*event*/) {
+    return false;
+}
+
 // TextEdit ------------------------------
 TextEdit::TextEdit(QWidget *parent)
     : QPlainTextEdit(parent)
@@ -75,6 +79,16 @@ void TextEdit::mouseReleaseEvent(QMouseEvent *event)
         }
     }
     QPlainTextEdit::mouseReleaseEvent(event);
+}
+
+void TextEdit::wheelEvent(QWheelEvent *event)
+{
+    for (auto extension : mExtensions) {
+        if (extension->wheel(event)) {
+            return;
+        }
+    }
+    QPlainTextEdit::wheelEvent(event);
 }
 
 void TextEdit::addExtension(TextEditExtension *extension)

--- a/src/TextEdit.h
+++ b/src/TextEdit.h
@@ -23,6 +23,8 @@ public:
 
     virtual bool mouseRelease(QMouseEvent *event);
 
+    virtual bool wheel(QWheelEvent *event);
+
 protected:
     TextEdit *mTextEdit;
 };
@@ -39,6 +41,7 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
     void keyReleaseEvent(QKeyEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
 
 private:
     QList<TextEditExtension*> mExtensions;

--- a/src/WheelZoomExtension.cpp
+++ b/src/WheelZoomExtension.cpp
@@ -1,0 +1,36 @@
+#include "WheelZoomExtension.h"
+
+#include <QDateTime>
+
+static const int SCROLL_TIMEOUT = 1000; // in milliseconds
+
+WheelZoomExtension::WheelZoomExtension(TextEdit *textEdit)
+    : TextEditExtension(textEdit), mPartialDelta(0), mLastUpdate(0)
+{}
+
+bool WheelZoomExtension::wheel(QWheelEvent *event)
+{
+    if (event->modifiers() != Qt::CTRL) {
+        return false;
+    }
+
+    int delta = event->angleDelta().y();
+    if (delta == 0) {
+        return false;
+    }
+
+    qint64 time = QDateTime::currentMSecsSinceEpoch();
+    if (time - mLastUpdate > SCROLL_TIMEOUT) {
+        mPartialDelta = 0;
+    }
+
+    mPartialDelta += delta;
+    int steps = mPartialDelta / QWheelEvent::DefaultDeltasPerStep;
+    if (steps != 0) {
+        emit adjustFontSize(steps);
+        mPartialDelta -= steps * QWheelEvent::DefaultDeltasPerStep;
+    }
+    mLastUpdate = time;
+    return true;
+}
+

--- a/src/WheelZoomExtension.cpp
+++ b/src/WheelZoomExtension.cpp
@@ -5,7 +5,7 @@
 static const int SCROLL_TIMEOUT = 1000; // in milliseconds
 
 WheelZoomExtension::WheelZoomExtension(TextEdit *textEdit)
-    : TextEditExtension(textEdit), mPartialDelta(0), mLastUpdate(0)
+    : TextEditExtension(textEdit)
 {}
 
 bool WheelZoomExtension::wheel(QWheelEvent *event)

--- a/src/WheelZoomExtension.h
+++ b/src/WheelZoomExtension.h
@@ -1,0 +1,22 @@
+#ifndef WHEELZOOMEXTENSION_H
+#define WHEELZOOMEXTENSION_H
+
+#include "TextEdit.h"
+
+class WheelZoomExtension : public TextEditExtension
+{
+    Q_OBJECT
+public:
+    explicit WheelZoomExtension(TextEdit *textEdit);
+
+    bool wheel(QWheelEvent *event) override;
+
+signals:
+    void adjustFontSize(int delta);
+
+private:
+    int mPartialDelta;
+    qint64 mLastUpdate;
+};
+
+#endif // WHEELZOOMEXTENSION_H

--- a/src/WheelZoomExtension.h
+++ b/src/WheelZoomExtension.h
@@ -15,8 +15,8 @@ signals:
     void adjustFontSize(int delta);
 
 private:
-    int mPartialDelta;
-    qint64 mLastUpdate;
+    int mPartialDelta = 0;
+    qint64 mLastUpdate = 0;
 };
 
 #endif // WHEELZOOMEXTENSION_H


### PR DESCRIPTION
Similarly to what browsers and also Kate/KWrite offer, the font size can be increased/decreased by scrolling while holding Ctrl pressed.

I implemented this as an extension and added support for wheel events to the extension framework. As this extension needs a way to call `MainWindow::adjustFontSize`, using a signal seemed to be most natural for me. If you have a better approach, I'm happy to refactor the code.

The wheel events can be fired at quite different intervals for different mouses/touchpads, making it necessary to integrate the delta values until a threshold is reached. The behavior feels natural for me both for my mouse (giving events with `delta == 120 == QWheelEvent::DefaultDeltasPerStep`) and for my touchpad (with very fine grained and irregular wheel events). In order to obtain a consistent behavior when starting to zoom again, I reset the partial value after one second. I think storing the time of the last event is simpler than triggering a `QTimer`, but if you disagree or think that the whole resetting is unnecessary, let me know.