### PR TITLE
Add support for Markdown-style tasks in lists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(APPLIB_SRCS
     Settings.cpp
     SettingsDialog.cpp
     SettingsDialog.ui
+    TaskExtension.cpp
     TextEdit.cpp
     WheelZoomExtension.cpp
     SearchWidget.cpp

--- a/src/IndentExtension.cpp
+++ b/src/IndentExtension.cpp
@@ -8,7 +8,7 @@
 static const int INDENT_SIZE = 4;
 
 static int findBulletSize(const QStringRef& ref) {
-    static QSet<QString> bullets = {"- ", "* ", "> "};
+    static QStringList bullets = {"- [ ] ", "- [x] ", "* [ ] ", "* [x] ", "- ", "* ", "> "};
     for (auto bullet : bullets) {
         if (ref.startsWith(bullet)) {
             return bullet.length();
@@ -205,7 +205,11 @@ void IndentExtension::insertIndentedLine() {
     if (cursor.columnNumber() > 0) {
         QString line = cursor.block().text();
         QString prefix = findCommonPrefix(line).text;
-        mTextEdit->insertPlainText('\n' + prefix);
+        if (prefix.endsWith("[x] ")) { // Create unchecked task item
+            mTextEdit->insertPlainText('\n' + prefix.left(prefix.size() - 4) + "[ ] ");
+        } else {
+            mTextEdit->insertPlainText('\n' + prefix);
+        }
     } else {
         mTextEdit->insertPlainText("\n");
     }

--- a/src/LinkExtension.cpp
+++ b/src/LinkExtension.cpp
@@ -36,8 +36,7 @@ bool LinkExtension::keyPress(QKeyEvent* event) {
         mTextEdit->viewport()->setCursor(Qt::PointingHandCursor);
     }
     if (ctrlPressed && enterPressed) {
-        openLinkUnderCursor();
-        return true;
+        return openLinkUnderCursor();
     }
     return false;
 }
@@ -56,9 +55,11 @@ bool LinkExtension::mouseRelease(QMouseEvent* event) {
     return false;
 }
 
-void LinkExtension::openLinkUnderCursor() {
+bool LinkExtension::openLinkUnderCursor() {
     QUrl url = getLinkUnderCursor(mTextEdit->textCursor());
     if (url.isValid()) {
         QDesktopServices::openUrl(url);
+        return true;
     }
+    return false;
 }

--- a/src/LinkExtension.cpp
+++ b/src/LinkExtension.cpp
@@ -12,7 +12,12 @@ static QUrl getLinkUnderCursor(const QTextCursor& cursor) {
     return LinkSyntaxHighlighter::getLinkAt(cursor.block().text(), cursor.positionInBlock());
 }
 
-LinkExtension::LinkExtension(TextEdit* textEdit) : TextEditExtension(textEdit) {
+LinkExtension::LinkExtension(TextEdit* textEdit)
+        : TextEditExtension(textEdit), mOpenLinkAction(std::make_unique<QAction>()) {
+    mOpenLinkAction->setText(tr("Go to link"));
+    mOpenLinkAction->setShortcut(Qt::CTRL | Qt::Key_G);
+    connect(mOpenLinkAction.get(), &QAction::triggered, this, &LinkExtension::openLinkUnderCursor);
+    mTextEdit->addAction(mOpenLinkAction.get());
 }
 
 void LinkExtension::aboutToShowContextMenu(QMenu* menu, const QPoint& pos) {
@@ -26,17 +31,16 @@ void LinkExtension::aboutToShowContextMenu(QMenu* menu, const QPoint& pos) {
         data->setUrls({url});
         qGuiApp->clipboard()->setMimeData(data);
     });
-    menu->addAction(tr("Open link"), this, [url] { QDesktopServices::openUrl(url); });
+    menu->addAction(mOpenLinkAction.get()->text(),
+                    this,
+                    [url] { QDesktopServices::openUrl(url); },
+                    mOpenLinkAction.get()->shortcut());
 }
 
 bool LinkExtension::keyPress(QKeyEvent* event) {
     bool ctrlPressed = event->modifiers() == Qt::CTRL;
-    bool enterPressed = event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return;
     if (ctrlPressed) {
         mTextEdit->viewport()->setCursor(Qt::PointingHandCursor);
-    }
-    if (ctrlPressed && enterPressed) {
-        return openLinkUnderCursor();
     }
     return false;
 }
@@ -55,11 +59,9 @@ bool LinkExtension::mouseRelease(QMouseEvent* event) {
     return false;
 }
 
-bool LinkExtension::openLinkUnderCursor() {
+void LinkExtension::openLinkUnderCursor() {
     QUrl url = getLinkUnderCursor(mTextEdit->textCursor());
     if (url.isValid()) {
         QDesktopServices::openUrl(url);
-        return true;
     }
-    return false;
 }

--- a/src/LinkExtension.h
+++ b/src/LinkExtension.h
@@ -3,6 +3,8 @@
 
 #include "TextEdit.h"
 
+#include <memory>
+
 class LinkExtension : public TextEditExtension {
     Q_OBJECT
 public:
@@ -17,7 +19,9 @@ public:
     bool mouseRelease(QMouseEvent* event) override;
 
 private:
-    bool openLinkUnderCursor();
+    void openLinkUnderCursor();
+
+    const std::unique_ptr<QAction> mOpenLinkAction;
 };
 
 #endif // LINKEXTENSION_H

--- a/src/LinkExtension.h
+++ b/src/LinkExtension.h
@@ -17,7 +17,7 @@ public:
     bool mouseRelease(QMouseEvent* event) override;
 
 private:
-    void openLinkUnderCursor();
+    bool openLinkUnderCursor();
 };
 
 #endif // LINKEXTENSION_H

--- a/src/LinkSyntaxHighlighter.cpp
+++ b/src/LinkSyntaxHighlighter.cpp
@@ -14,6 +14,8 @@
 static const char LINK_REGEX[] =
     "\\b(https?://|ftp://|file:/)[" COMMON_CHARS MIDDLE_CHARS "]+[" COMMON_CHARS "]";
 
+static const char TASK_REGEX[] = "^\\s*[-\\*] \\[([x ])\\]";
+
 LinkSyntaxHighlighter::LinkSyntaxHighlighter(QTextDocument* document)
         : QSyntaxHighlighter(document) {
 }
@@ -30,6 +32,12 @@ void LinkSyntaxHighlighter::highlightBlock(const QString& text) {
         QRegularExpressionMatch match = it.next();
         setFormat(match.capturedStart(), match.capturedLength(), linkFormat);
     }
+
+    expression = QRegularExpression(TASK_REGEX);
+    for (auto it = expression.globalMatch(text); it.hasNext();) {
+        QRegularExpressionMatch match = it.next();
+        setFormat(match.capturedStart(1), match.capturedLength(1), linkFormat);
+    }
 }
 
 QUrl LinkSyntaxHighlighter::getLinkAt(const QString& text, int position) {
@@ -41,4 +49,16 @@ QUrl LinkSyntaxHighlighter::getLinkAt(const QString& text, int position) {
         }
     }
     return QUrl();
+}
+
+int LinkSyntaxHighlighter::getTaskCheckmarkPosAt(const QString& text, int position) {
+    QRegularExpression expression(TASK_REGEX);
+    for (auto it = expression.globalMatch(text); it.hasNext();) {
+        QRegularExpressionMatch match = it.next();
+        // Also match the surrounding brackets to make clicking easier
+        if (match.capturedStart(1) - 1 <= position && position <= match.capturedEnd(1)) {
+            return match.capturedStart(1); // Position of 'x' or ' ' character
+        }
+    }
+    return -1;
 }

--- a/src/LinkSyntaxHighlighter.cpp
+++ b/src/LinkSyntaxHighlighter.cpp
@@ -14,7 +14,7 @@
 static const char LINK_REGEX[] =
     "\\b(https?://|ftp://|file:/)[" COMMON_CHARS MIDDLE_CHARS "]+[" COMMON_CHARS "]";
 
-static const char TASK_REGEX[] = "^\\s*[-\\*] \\[([x ])\\]";
+static const char TASK_REGEX[] = "^\\s*[-\\*] (\\[[x ]\\])";
 
 LinkSyntaxHighlighter::LinkSyntaxHighlighter(QTextDocument* document)
         : QSyntaxHighlighter(document) {
@@ -33,10 +33,13 @@ void LinkSyntaxHighlighter::highlightBlock(const QString& text) {
         setFormat(match.capturedStart(), match.capturedLength(), linkFormat);
     }
 
+    QTextCharFormat taskFormat;
+    taskFormat.setForeground(linkColor);
+
     expression = QRegularExpression(TASK_REGEX);
     for (auto it = expression.globalMatch(text); it.hasNext();) {
         QRegularExpressionMatch match = it.next();
-        setFormat(match.capturedStart(1), match.capturedLength(1), linkFormat);
+        setFormat(match.capturedStart(1), match.capturedLength(1), taskFormat);
     }
 }
 
@@ -55,9 +58,8 @@ int LinkSyntaxHighlighter::getTaskCheckmarkPosAt(const QString& text, int positi
     QRegularExpression expression(TASK_REGEX);
     for (auto it = expression.globalMatch(text); it.hasNext();) {
         QRegularExpressionMatch match = it.next();
-        // Also match the surrounding brackets to make clicking easier
-        if (match.capturedStart(1) - 1 <= position && position <= match.capturedEnd(1)) {
-            return match.capturedStart(1); // Position of 'x' or ' ' character
+        if (match.capturedStart(1) <= position && position < match.capturedEnd(1)) {
+            return match.capturedStart(1) + 1; // Position of 'x' or ' ' character
         }
     }
     return -1;

--- a/src/LinkSyntaxHighlighter.h
+++ b/src/LinkSyntaxHighlighter.h
@@ -8,6 +8,7 @@ public:
     LinkSyntaxHighlighter(QTextDocument* document);
 
     static QUrl getLinkAt(const QString& text, int position);
+    static int getTaskCheckmarkPosAt(const QString& text, int position);
 
 protected:
     void highlightBlock(const QString& text) override;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -20,6 +20,7 @@
 #include "SearchWidget.h"
 #include "Settings.h"
 #include "SettingsDialog.h"
+#include "TaskExtension.h"
 #include "TextEdit.h"
 #include "WheelZoomExtension.h"
 
@@ -87,6 +88,7 @@ MainWindow::~MainWindow() {
 void MainWindow::setupTextEdit() {
     mTextEdit->setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
     mTextEdit->addExtension(new LinkExtension(mTextEdit));
+    mTextEdit->addExtension(new TaskExtension(mTextEdit));
     mTextEdit->addExtension(new IndentExtension(mTextEdit));
 
     WheelZoomExtension* wheelZoomExtension = new WheelZoomExtension(mTextEdit);

--- a/src/MoveLinesExtension.cpp
+++ b/src/MoveLinesExtension.cpp
@@ -26,6 +26,7 @@ MoveLinesExtension::~MoveLinesExtension() {
 void MoveLinesExtension::aboutToShowEditContextMenu(QMenu* menu, const QPoint& /*pos*/) {
     menu->addAction(mMoveUpAction.get());
     menu->addAction(mMoveDownAction.get());
+    menu->addSeparator();
 }
 
 void MoveLinesExtension::moveUp() {

--- a/src/MoveLinesExtension.cpp
+++ b/src/MoveLinesExtension.cpp
@@ -26,7 +26,6 @@ MoveLinesExtension::~MoveLinesExtension() {
 void MoveLinesExtension::aboutToShowEditContextMenu(QMenu* menu, const QPoint& /*pos*/) {
     menu->addAction(mMoveUpAction.get());
     menu->addAction(mMoveDownAction.get());
-    menu->addSeparator();
 }
 
 void MoveLinesExtension::moveUp() {

--- a/src/TaskExtension.cpp
+++ b/src/TaskExtension.cpp
@@ -18,9 +18,9 @@ static void toggleTask(QTextCursor* cursor, int pos) {
     cursor->beginEditBlock();
     cursor->setPosition(pos + cursor->block().position());
     cursor->movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
-    QString c = cursor->selectedText();
+    QString text = cursor->selectedText();
     cursor->movePosition(QTextCursor::Right);
-    if (c == "x") {
+    if (text == "x") {
         cursor->insertText(" ");
     } else {
         cursor->insertText("x");

--- a/src/TaskExtension.cpp
+++ b/src/TaskExtension.cpp
@@ -66,13 +66,17 @@ void TaskExtension::insertOrToggleTask() {
         return;
     } else if (match.captured(2).isEmpty()) {
         // Not in list
+        cursor.beginEditBlock();
         cursor.setPosition(cursor.block().position() + match.capturedEnd(1));
         cursor.insertText("- [ ] ");
+        cursor.endEditBlock();
     } else {
         // In list, only add checkbox
         bool trailingSpace = !match.captured(3).isEmpty();
+        cursor.beginEditBlock();
         cursor.setPosition(cursor.block().position() + match.capturedEnd(2));
         cursor.insertText(trailingSpace ? " [ ]" : " [ ] ");
+        cursor.endEditBlock();
     }
 }
 

--- a/src/TaskExtension.cpp
+++ b/src/TaskExtension.cpp
@@ -1,0 +1,107 @@
+#include "TaskExtension.h"
+
+#include <QMenu>
+#include <QRegularExpression>
+
+#include "LinkSyntaxHighlighter.h"
+
+static const char INSERT_TASK_REGEX[] = "^(\\s*)([-\\*])?(\\s)?(\\[[x ]\\])?";
+
+static int getTaskCheckmarkPosUnderCursor(const QTextCursor& cursor) {
+    return LinkSyntaxHighlighter::getTaskCheckmarkPosAt(cursor.block().text(),
+                                                        cursor.positionInBlock());
+}
+
+static void toggleTask(QTextCursor* cursor, int pos) {
+    // First insert the new character after the old one, then delete the old character.
+    // This prevents the main cursor from moving as a side effect from the editing.
+    cursor->beginEditBlock();
+    cursor->setPosition(pos + cursor->block().position());
+    cursor->movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
+    QString c = cursor->selectedText();
+    cursor->movePosition(QTextCursor::Right);
+    if (c == "x") {
+        cursor->insertText(" ");
+    } else {
+        cursor->insertText("x");
+    }
+    cursor->movePosition(QTextCursor::Left);
+    cursor->deletePreviousChar();
+    cursor->endEditBlock();
+}
+
+TaskExtension::TaskExtension(TextEdit* textEdit)
+        : TextEditExtension(textEdit), mInsertToggleTaskAction(std::make_unique<QAction>()) {
+    mInsertToggleTaskAction->setText(tr("Insert/toggle task"));
+    mInsertToggleTaskAction->setShortcut(Qt::ALT | Qt::Key_T);
+    connect(mInsertToggleTaskAction.get(), &QAction::triggered, this, &TaskExtension::insertTask);
+    mTextEdit->addAction(mInsertToggleTaskAction.get());
+}
+
+void TaskExtension::aboutToShowContextMenu(QMenu* menu, const QPoint& pos) {
+    QTextCursor cursor = mTextEdit->cursorForPosition(pos);
+    int checkmarkPos = getTaskCheckmarkPosUnderCursor(cursor);
+    if (checkmarkPos == -1) {
+        return;
+    }
+    menu->addAction(tr("Toggle task completion"), this, [this, pos, checkmarkPos] {
+        // TODO: why can I not pass the cursor here?
+        QTextCursor c = mTextEdit->cursorForPosition(pos);
+        toggleTask(&c, checkmarkPos);
+    });
+}
+
+void TaskExtension::aboutToShowEditContextMenu(QMenu* menu, const QPoint& /*pos*/) {
+    menu->addAction(mInsertToggleTaskAction.get());
+}
+
+bool TaskExtension::keyPress(QKeyEvent* event) {
+    bool ctrlPressed = event->modifiers() == Qt::CTRL;
+    bool enterPressed = event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return;
+    if (ctrlPressed && enterPressed) {
+        return toggleTaskUnderCursor();
+    }
+    return false;
+}
+
+bool TaskExtension::mouseRelease(QMouseEvent* event) {
+    if (event->modifiers() == Qt::CTRL) {
+        toggleTaskUnderCursor();
+    }
+    return false;
+}
+
+void TaskExtension::insertTask() {
+    auto cursor = mTextEdit->textCursor();
+    QString text = cursor.block().text();
+
+    QRegularExpression expression(INSERT_TASK_REGEX);
+    QRegularExpressionMatch match = expression.match(text);
+    if (!match.hasMatch()) {
+        // Should not happen
+        return;
+    } else if (!match.captured(3).isEmpty() && !match.captured(4).isEmpty()) {
+        // Line already contains a task, toggle completion
+        toggleTask(&cursor, match.capturedStart(4) + 1);
+        return;
+    } else if (match.captured(2).isEmpty()) {
+        // Not in list
+        cursor.setPosition(cursor.block().position() + match.capturedEnd(1));
+        cursor.insertText("- [ ] ");
+    } else {
+        // In list, only add checkbox
+        bool trailingSpace = !match.captured(3).isEmpty();
+        cursor.setPosition(cursor.block().position() + match.capturedEnd(2));
+        cursor.insertText(trailingSpace ? " [ ]" : " [ ] ");
+    }
+}
+
+bool TaskExtension::toggleTaskUnderCursor() {
+    auto cursor = mTextEdit->textCursor();
+    int pos = getTaskCheckmarkPosUnderCursor(cursor);
+    if (pos == -1) {
+        return false;
+    }
+    toggleTask(&cursor, pos);
+    return true;
+}

--- a/src/TaskExtension.h
+++ b/src/TaskExtension.h
@@ -12,19 +12,16 @@ class TaskExtension : public TextEditExtension {
 public:
     explicit TaskExtension(TextEdit* textEdit);
 
-    void aboutToShowContextMenu(QMenu* menu, const QPoint& pos) override;
     void aboutToShowEditContextMenu(QMenu* menu, const QPoint& pos) override;
-
-    bool keyPress(QKeyEvent* event) override;
 
     bool mouseRelease(QMouseEvent* event) override;
 
-    void insertTask();
+    void insertOrToggleTask();
 
 private:
-    bool toggleTaskUnderCursor();
+    void toggleTaskUnderCursor();
 
-    const std::unique_ptr<QAction> mInsertToggleTaskAction;
+    const std::unique_ptr<QAction> mTaskAction;
 };
 
 #endif // TASKEXTENSION_H

--- a/src/TaskExtension.h
+++ b/src/TaskExtension.h
@@ -1,0 +1,30 @@
+#ifndef TASKEXTENSION_H
+#define TASKEXTENSION_H
+
+#include "TextEdit.h"
+
+#include <QAction>
+
+#include <memory>
+
+class TaskExtension : public TextEditExtension {
+    Q_OBJECT
+public:
+    explicit TaskExtension(TextEdit* textEdit);
+
+    void aboutToShowContextMenu(QMenu* menu, const QPoint& pos) override;
+    void aboutToShowEditContextMenu(QMenu* menu, const QPoint& pos) override;
+
+    bool keyPress(QKeyEvent* event) override;
+
+    bool mouseRelease(QMouseEvent* event) override;
+
+    void insertTask();
+
+private:
+    bool toggleTaskUnderCursor();
+
+    const std::unique_ptr<QAction> mInsertToggleTaskAction;
+};
+
+#endif // TASKEXTENSION_H

--- a/src/translations/nanonote_de.ts
+++ b/src/translations/nanonote_de.ts
@@ -20,7 +20,11 @@
     </message>
     <message>
         <source>Open link</source>
-        <translation>Link öffnen</translation>
+        <translation type="vanished">Link öffnen</translation>
+    </message>
+    <message>
+        <source>Go to link</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -229,10 +233,6 @@ Das ist alles, was es zu sagen gibt, jetzt kannst du diesen Text löschen und an
 </context>
 <context>
     <name>TaskExtension</name>
-    <message>
-        <source>Toggle task completion</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Insert/toggle task</source>
         <translation type="unfinished"></translation>

--- a/src/translations/nanonote_de.ts
+++ b/src/translations/nanonote_de.ts
@@ -228,6 +228,17 @@ Das ist alles, was es zu sagen gibt, jetzt kannst du diesen Text löschen und an
     </message>
 </context>
 <context>
+    <name>TaskExtension</name>
+    <message>
+        <source>Toggle task completion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert/toggle task</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TextEdit</name>
     <message>
         <source>Edit</source>

--- a/src/translations/nanonote_en.ts
+++ b/src/translations/nanonote_en.ts
@@ -17,50 +17,54 @@
 <context>
     <name>LinkExtension</name>
     <message>
-        <location filename="../LinkExtension.cpp" line="24"/>
+        <location filename="../LinkExtension.cpp" line="17"/>
+        <source>Go to link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LinkExtension.cpp" line="29"/>
         <source>Copy link address</source>
         <translation>Copy link address</translation>
     </message>
     <message>
-        <location filename="../LinkExtension.cpp" line="29"/>
         <source>Open link</source>
-        <translation>Open link</translation>
+        <translation type="vanished">Open link</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../MainWindow.cpp" line="112"/>
+        <location filename="../MainWindow.cpp" line="114"/>
         <source>Increase Font Size</source>
         <translation>Increase Font Size</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="115"/>
+        <location filename="../MainWindow.cpp" line="117"/>
         <source>Decrease Font Size</source>
         <translation>Decrease Font Size</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="118"/>
+        <location filename="../MainWindow.cpp" line="120"/>
         <source>Reset Font Size</source>
         <translation>Reset Font Size</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="129"/>
+        <location filename="../MainWindow.cpp" line="131"/>
         <source>Always on Top</source>
         <translation>Always on Top</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="134"/>
+        <location filename="../MainWindow.cpp" line="136"/>
         <source>Settings | About...</source>
         <translation>Settings | About...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="139"/>
+        <location filename="../MainWindow.cpp" line="141"/>
         <source>Find</source>
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="159"/>
+        <location filename="../MainWindow.cpp" line="161"/>
         <source>Welcome to Nanonote!
 
 Nanonote is a minimalist note taking application.
@@ -193,6 +197,14 @@ That&apos;s all there is to say, now you can erase this text and start taking no
 &lt;p&gt;I hope you enjoy Nanonote!&lt;/p&gt;
 &lt;p&gt;If you do, it would be lovely if you could &lt;a href=&apos;%1&apos;&gt;support my work&lt;/a&gt; on free and open source software.&lt;/p&gt;
 &lt;p align=&quot;right&quot;&gt;― Aurélien&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>TaskExtension</name>
+    <message>
+        <location filename="../TaskExtension.cpp" line="35"/>
+        <source>Insert/toggle task</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/translations/nanonote_es.ts
+++ b/src/translations/nanonote_es.ts
@@ -185,6 +185,17 @@ Y esto es todo lo que hay que decir, ahora puedes eliminar este texto ¡y empeza
     </message>
 </context>
 <context>
+    <name>TaskExtension</name>
+    <message>
+        <source>Toggle task completion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert/toggle task</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TextEdit</name>
     <message>
         <source>Edit</source>

--- a/src/translations/nanonote_es.ts
+++ b/src/translations/nanonote_es.ts
@@ -20,7 +20,11 @@
     </message>
     <message>
         <source>Open link</source>
-        <translation>Abrir enlace</translation>
+        <translation type="vanished">Abrir enlace</translation>
+    </message>
+    <message>
+        <source>Go to link</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -186,10 +190,6 @@ Y esto es todo lo que hay que decir, ahora puedes eliminar este texto ¡y empeza
 </context>
 <context>
     <name>TaskExtension</name>
-    <message>
-        <source>Toggle task completion</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Insert/toggle task</source>
         <translation type="unfinished"></translation>

--- a/src/translations/nanonote_fr.ts
+++ b/src/translations/nanonote_fr.ts
@@ -20,7 +20,11 @@
     </message>
     <message>
         <source>Open link</source>
-        <translation>Ouvrir le lien</translation>
+        <translation type="vanished">Ouvrir le lien</translation>
+    </message>
+    <message>
+        <source>Go to link</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -186,10 +190,6 @@ C&apos;est tout ce qu&apos;il y a dire, maintenant vous pouvez effacer ce texte 
 </context>
 <context>
     <name>TaskExtension</name>
-    <message>
-        <source>Toggle task completion</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Insert/toggle task</source>
         <translation type="unfinished"></translation>

--- a/src/translations/nanonote_fr.ts
+++ b/src/translations/nanonote_fr.ts
@@ -185,6 +185,17 @@ C&apos;est tout ce qu&apos;il y a dire, maintenant vous pouvez effacer ce texte 
     </message>
 </context>
 <context>
+    <name>TaskExtension</name>
+    <message>
+        <source>Toggle task completion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert/toggle task</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TextEdit</name>
     <message>
         <source>Edit</source>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(tests
     MoveLinesExtensionTest.cpp
     SearchWidgetTest.cpp
     Catch2QtUtils.cpp
+    TaskExtensionTest.cpp
     TextUtils.cpp
 )
 

--- a/tests/IndentExtensionTest.cpp
+++ b/tests/IndentExtensionTest.cpp
@@ -149,4 +149,20 @@ TEST_CASE("textedit") {
                 == QString("\n"
                            "|c"));
     }
+
+    SECTION("Return on indented bullet line inserts new bullet") {
+        setupTextEditContent(edit, "    - item|");
+        QTest::keyClick(edit, Qt::Key_Return);
+        REQUIRE(dumpTextEditContent(edit)
+                == QString("    - item\n"
+                           "    - |"));
+    }
+
+    SECTION("Return on indented checked task line inserts new unchecked task") {
+        setupTextEditContent(edit, "    - [x] item|");
+        QTest::keyClick(edit, Qt::Key_Return);
+        REQUIRE(dumpTextEditContent(edit)
+                == QString("    - [x] item\n"
+                           "    - [ ] |"));
+    }
 }

--- a/tests/LinkSyntaxHighlighterTest.cpp
+++ b/tests/LinkSyntaxHighlighterTest.cpp
@@ -18,3 +18,22 @@ TEST_CASE("getLinkAt") {
         REQUIRE(LinkSyntaxHighlighter::getLinkAt(text, text.length() - 4) == QUrl());
     }
 }
+
+TEST_CASE("getTaskCheckmarkPosAt") {
+    QString text = QString("    - [x] test task");
+    SECTION("before task") {
+        REQUIRE(LinkSyntaxHighlighter::getTaskCheckmarkPosAt(text, 5) == -1);
+    }
+    SECTION("start of task") {
+        REQUIRE(LinkSyntaxHighlighter::getTaskCheckmarkPosAt(text, 6) == 7);
+    }
+    SECTION("inside task") {
+        REQUIRE(LinkSyntaxHighlighter::getTaskCheckmarkPosAt(text, 8) == 7);
+    }
+    SECTION("end of task") {
+        REQUIRE(LinkSyntaxHighlighter::getTaskCheckmarkPosAt(text, 9) == -1);
+    }
+    SECTION("after task") {
+        REQUIRE(LinkSyntaxHighlighter::getTaskCheckmarkPosAt(text, 10) == -1);
+    }
+}

--- a/tests/TaskExtensionTest.cpp
+++ b/tests/TaskExtensionTest.cpp
@@ -1,0 +1,54 @@
+#include "TaskExtension.h"
+
+#include <QMainWindow>
+#include <QTest>
+#include <QTextCursor>
+
+#include <catch2/catch_all.hpp>
+
+#include "Catch2QtUtils.h"
+#include "TextUtils.h"
+
+TEST_CASE("taskextension") {
+    QMainWindow window;
+    TextEdit* edit = new TextEdit;
+    window.setCentralWidget(edit);
+    TaskExtension extension(edit);
+    edit->addExtension(&extension);
+
+    SECTION("Toggle unchecked task") {
+        setupTextEditContent(edit, "- [ ] task|");
+        extension.insertOrToggleTask();
+        REQUIRE(dumpTextEditContent(edit) == QString("- [x] task|"));
+    }
+
+    SECTION("Toggle checked task") {
+        setupTextEditContent(edit, "- [x] task|");
+        extension.insertOrToggleTask();
+        REQUIRE(dumpTextEditContent(edit) == QString("- [ ] task|"));
+    }
+
+    SECTION("Insert task") {
+        setupTextEditContent(edit, "ta|sk");
+        extension.insertOrToggleTask();
+        REQUIRE(dumpTextEditContent(edit) == QString("- [ ] ta|sk"));
+    }
+
+    SECTION("Insert task in indented line") {
+        setupTextEditContent(edit, "    |task");
+        extension.insertOrToggleTask();
+        REQUIRE(dumpTextEditContent(edit) == QString("    - [ ] |task"));
+    }
+
+    SECTION("Insert task in existing list") {
+        setupTextEditContent(edit, "- task|");
+        extension.insertOrToggleTask();
+        REQUIRE(dumpTextEditContent(edit) == QString("- [ ] task|"));
+    }
+
+    SECTION("Insert task in existing indented list") {
+        setupTextEditContent(edit, "    - task|");
+        extension.insertOrToggleTask();
+        REQUIRE(dumpTextEditContent(edit) == QString("    - [ ] task|"));
+    }
+}


### PR DESCRIPTION
The syntax for tasks is `- [ ]` or `* [ ]` for unchecked tasks and `- [x]` or `* [x]` for checked tasks. Tasks are highlighted and treated like links and the completion can be toggled with Ctrl+Enter, Ctrl+Click, and via the context menu. There is another keyboard shortcut that turns the current line into a task and, if it already is a task, toggles it. This way, it is not necessary to manually type the brackets.

I've been using this for the last few days and found it quite useful. I'm curious what you think and if you even want this feature in nanonote. (At least when not using the feature, the impact is minimal. Just one more entry in the context menu.)

Some other notes:

- I expect that you will want to see some tests before merging this. I'll work on that if your general feedback is positive.
- I also appreciate any other feedback about the code or about how this feature should behave. (At least, how I handled the "Toggle task completion" action in the context menu does not seem ideal.)
- The implementation is not as self-contained as I would have liked. There can only be one syntax highlighter, so I had to extend the existing one. For auto-inserting the task check boxes when pressing enter, it is a lot easier to add this to the `IndentExtension` than to duplicate most of the functionality.
- As the keyboard shortcut for the "Insert/toggle task" action, I now use `Alt+T` because `Ctrl+T` is used for "Always on Top". The obvious alternative would be `Ctrl+Shift+T` but that is harder to type. Personally, I quite like the idea of using `Ctrl+T` for the task action and `Ctrl+Shift+T` for "Always on Top". "Always on Top" is really useful sometimes, but over the years, I probably enabled it more often by accident than on purpose. Making this a bit harder is actually an improvement for me. Still, you probably don't want to change the shortcuts you chose, and I'm also happy to just patch the shortcuts for myself.