### PR TITLE
Do not change cursor to pointing-hand when not over a link

### DIFF
--- a/src/LinkExtension.cpp
+++ b/src/LinkExtension.cpp
@@ -1,6 +1,7 @@
 #include "LinkExtension.h"
 
 #include <QClipboard>
+#include <QCursor>
 #include <QDesktopServices>
 #include <QGuiApplication>
 #include <QMenu>
@@ -38,17 +39,22 @@ void LinkExtension::aboutToShowContextMenu(QMenu* menu, const QPoint& pos) {
 }
 
 bool LinkExtension::keyPress(QKeyEvent* event) {
-    bool ctrlPressed = event->modifiers() == Qt::CTRL;
-    if (ctrlPressed) {
-        mTextEdit->viewport()->setCursor(Qt::PointingHandCursor);
+    if (event->modifiers() == Qt::CTRL) {
+        mTextEdit->viewport()->setMouseTracking(true);
+        updateMouseCursor();
     }
     return false;
 }
 
 bool LinkExtension::keyRelease(QKeyEvent* event) {
     if (event->modifiers() != Qt::CTRL) {
-        mTextEdit->viewport()->setCursor(Qt::IBeamCursor);
+        reset();
     }
+    return false;
+}
+
+bool LinkExtension::mouseMove(QMouseEvent* event) {
+    updateMouseCursor();
     return false;
 }
 
@@ -64,4 +70,17 @@ void LinkExtension::openLinkUnderCursor() {
     if (url.isValid()) {
         QDesktopServices::openUrl(url);
     }
+}
+
+void LinkExtension::updateMouseCursor() {
+    auto mousePos = mTextEdit->viewport()->mapFromGlobal(QCursor::pos());
+    auto textCursor = mTextEdit->cursorForPosition(mousePos);
+    auto shape =
+        getLinkUnderCursor(textCursor).isValid() ? Qt::PointingHandCursor : Qt::IBeamCursor;
+    mTextEdit->viewport()->setCursor(shape);
+}
+
+void LinkExtension::reset() {
+    mTextEdit->viewport()->setMouseTracking(false);
+    mTextEdit->viewport()->setCursor(Qt::IBeamCursor);
 }

--- a/src/LinkExtension.h
+++ b/src/LinkExtension.h
@@ -16,10 +16,14 @@ public:
 
     bool keyRelease(QKeyEvent* event) override;
 
+    bool mouseMove(QMouseEvent* event) override;
+
     bool mouseRelease(QMouseEvent* event) override;
 
 private:
+    void updateMouseCursor();
     void openLinkUnderCursor();
+    void reset();
 
     const std::unique_ptr<QAction> mOpenLinkAction;
 };

--- a/src/TextEdit.cpp
+++ b/src/TextEdit.cpp
@@ -33,6 +33,10 @@ bool TextEditExtension::mouseRelease(QMouseEvent* /*event*/) {
     return false;
 }
 
+bool TextEditExtension::mouseMove(QMouseEvent* /*event*/) {
+    return false;
+}
+
 bool TextEditExtension::wheel(QWheelEvent* /*event*/) {
     return false;
 }
@@ -89,6 +93,15 @@ void TextEdit::mouseReleaseEvent(QMouseEvent* event) {
         }
     }
     QPlainTextEdit::mouseReleaseEvent(event);
+}
+
+void TextEdit::mouseMoveEvent(QMouseEvent* event) {
+    for (auto extension : mExtensions) {
+        if (extension->mouseMove(event)) {
+            return;
+        }
+    }
+    QPlainTextEdit::mouseMoveEvent(event);
 }
 
 void TextEdit::wheelEvent(QWheelEvent* event) {

--- a/src/TextEdit.h
+++ b/src/TextEdit.h
@@ -27,6 +27,8 @@ public:
 
     virtual bool mouseRelease(QMouseEvent* event);
 
+    virtual bool mouseMove(QMouseEvent* event);
+
     virtual bool wheel(QWheelEvent* event);
 
 protected:
@@ -45,6 +47,7 @@ protected:
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
 
 private:


### PR DESCRIPTION
This makes the behavior of holding Ctrl nicer: now the cursor remains the I-beam one until it is over a link, just like in a we browser.