### PR TITLE
Fix bad icon on search bar close button

### DIFF
--- a/src/SearchWidget.ui
+++ b/src/SearchWidget.ui
@@ -24,7 +24,7 @@
    <item row="0" column="5">
     <widget class="QToolButton" name="closeButton">
      <property name="text">
-      <string notr="true">⛌</string>
+      <string notr="true">⨯</string>
      </property>
      <property name="autoRaise">
       <bool>true</bool>


### PR DESCRIPTION
The "cross" character used for the close button was not available in some fonts, such as Liberation. Replace it with a more widespread character.