### PR TITLE
Remove `em` elements from Appstream release descriptions

### DIFF
--- a/src/linux/nanonote.metainfo.xml
+++ b/src/linux/nanonote.metainfo.xml
@@ -27,9 +27,7 @@
   <releases>
     <release version="1.3.93" date="2023-04-03">
       <description>
-        <p>
-          <em>Fixed</em>
-        </p>
+        <p>Fixed</p>
         <ul>
           <li>Fixed a typo in the Appstream ID, which made creating a Flatpak for the app complicated.</li>
         </ul>
@@ -37,9 +35,7 @@
     </release>
     <release version="1.3.92" date="2023-04-02">
       <description>
-        <p>
-          <em>Added</em>
-        </p>
+        <p>Added</p>
         <ul>
           <li>Nanonote now highlights Markdown-like headings.</li>
         </ul>
@@ -47,30 +43,22 @@
     </release>
     <release version="1.3.91" date="2023-03-12">
       <description>
-        <p>
-          <em>Added</em>
-        </p>
+        <p>Added</p>
         <ul>
           <li>Add support for Markdown-style tasks in lists (Daniel Laidig)</li>
           <li>Add tips page (Aurelien Gateau)</li>
         </ul>
-        <p>
-          <em>Changed</em>
-        </p>
+        <p>Changed</p>
         <ul>
           <li>Use Ctrl+G to open links and Ctrl+Enter for tasks (Daniel Laidig)</li>
         </ul>
-        <p>
-          <em>Fixed</em>
-        </p>
+        <p>Fixed</p>
         <ul>
           <li>Make sure standard actions like Copy or Paste are translated (Aurelien Gateau)</li>
           <li>Show keyboard shortcuts in context menus on macOS (Daniel Laidig)</li>
           <li>Do not change cursor to pointing-hand when not over a link (Aurelien Gateau)</li>
         </ul>
-        <p>
-          <em>Internals</em>
-        </p>
+        <p>Internals</p>
         <ul>
           <li>CI: Bump Ubuntu to 20.04 and macOS to 11 (Aurelien Gateau)</li>
           <li>CI: Install clang-format from muttleyxd/clang-tools-static-binaries (Aurelien Gateau)</li>
@@ -82,15 +70,11 @@
     </release>
     <release version="1.3.0" date="2020-10-03">
       <description>
-        <p>
-          <em>Changed</em>
-        </p>
+        <p>Changed</p>
         <ul>
           <li>Update Spanish translation (Victorhck)</li>
         </ul>
-        <p>
-          <em>Fixed</em>
-        </p>
+        <p>Fixed</p>
         <ul>
           <li>Properly encode URL of the note path (Aurelien Gateau)</li>
           <li>Fix untranslated text in About tab on Linux (Aurelien Gateau)</li>
@@ -99,18 +83,14 @@
     </release>
     <release version="1.2.91" date="2020-09-28">
       <description>
-        <p>
-          <em>Added</em>
-        </p>
+        <p>Added</p>
         <ul>
           <li>You can now search inside your notes with the new search bar (Pavol Oresky)</li>
           <li>You can now move selected lines up and down with Alt+Shift+Up and Down (Aurelien Gateau)</li>
           <li>macOS dmg (Aurelien Gateau)</li>
           <li>Windows installer (Aurelien Gateau)</li>
         </ul>
-        <p>
-          <em>Changed</em>
-        </p>
+        <p>Changed</p>
         <ul>
           <li>Reorganized context menu: added "Edit" and "View" submenus (Aurelien Gateau)</li>
         </ul>
@@ -118,18 +98,14 @@
     </release>
     <release version="1.2.0" date="2019-05-11">
       <description>
-        <p>
-          <em>Added</em>
-        </p>
+        <p>Added</p>
         <ul>
           <li>New German translation by Vinzenz Vietzke</li>
           <li>Allow changing the font size using Ctrl + mouse wheel (Daniel Laidig)</li>
           <li>Use the link color of the color theme instead of an hardcoded blue (Daniel Laidig)</li>
           <li>Added a way to reset the font size to the default value (Daniel Laidig)</li>
         </ul>
-        <p>
-          <em>Fixed</em>
-        </p>
+        <p>Fixed</p>
         <ul>
           <li>Added explanation of how to open URLs to the welcome text (Robert Barat)</li>
           <li>Allow '@' in URLs (Aurelien Gateau)</li>
@@ -139,17 +115,13 @@
     </release>
     <release version="1.1.0" date="2019-02-04">
       <description>
-        <p>
-          <em>Added</em>
-        </p>
+        <p>Added</p>
         <ul>
           <li>Pressing tab now indents the whole line when the cursor is at the beginning of a list item (Daniel Laidig).</li>
           <li>Pressing Enter on an empty list item now unindents, then removes the bullet (Aurelien Gateau).</li>
           <li>Added French and Spanish translations (Aurelien Gateau, Victorhck).</li>
         </ul>
-        <p>
-          <em>Fixed</em>
-        </p>
+        <p>Fixed</p>
         <ul>
           <li>Improved url detection: '+', '%' and '~' are now allowed in the middle of urls (Aurelien Gateau).</li>
           <li>Fixed wrong indentation behavior in upward selections (Aurelien Gateau).</li>
@@ -158,17 +130,13 @@
     </release>
     <release version="1.0.1" date="2019-01-12">
       <description>
-        <p>
-          <em>Added</em>
-        </p>
+        <p>Added</p>
         <ul>
           <li>Added unit-tests.</li>
           <li>Added Travis integration.</li>
           <li>Added rpm and deb packages generated using CPack.</li>
         </ul>
-        <p>
-          <em>Fixed</em>
-        </p>
+        <p>Fixed</p>
         <ul>
           <li>Fixed indentation and make it respect indentation columns.</li>
           <li>Made it possible to indent/unindent selected lines with Tab/Shift+Tab.</li>
@@ -178,9 +146,7 @@
     </release>
     <release version="1.0.0" date="2018-12-30">
       <description>
-        <p>
-          <em>Added</em>
-        </p>
+        <p>Added</p>
         <ul>
           <li>First release</li>
         </ul>

--- a/tasks.py
+++ b/tasks.py
@@ -87,8 +87,7 @@ def update_appstream_releases(c):
         description_et = ET.SubElement(release_et, "description")
         for change_type, changes in release.changes.items():
             p_et = ET.SubElement(description_et, "p")
-            em_et = ET.SubElement(p_et, "em")
-            em_et.text = change_type
+            p_et.text = change_type
             ul_et = ET.SubElement(description_et, "ul")
             for change in changes:
                 li_et = ET.SubElement(ul_et, "li")


### PR DESCRIPTION
Flathub does not interpret them, so they show up as raw text.
